### PR TITLE
Rewrite `Toggle Wi-Fi` AppleScript Without Using Heredoc

### DIFF
--- a/scripts/macos-automation/toggle-wifi.applescript
+++ b/scripts/macos-automation/toggle-wifi.applescript
@@ -1,14 +1,13 @@
 #!/usr/bin/osascript
 
-do shell script "/bin/zsh -s << 'EOF'
-device=$(networksetup -listallhardwareports | awk '$3==\"Wi-Fi\" {getline;print}' | awk '{print $2}')
-power=$(networksetup -getairportpower \"$device\" | awk '{print $4}' | tr '[:upper:]' '[:lower:]')
+set device to (do shell script "networksetup -listallhardwareports | awk '$3==\"Wi-Fi\" {getline;print}' | awk '{print $2}'")
+set power to (do shell script "networksetup -getairportpower " & device & " | awk '{print $4}' | tr '[:upper:]' '[:lower:]'")
 
-if [[ \"$power\" == 'on' ]]; then
-	opposite_power='off'
+set opposite_power to ""
+if power = "on" then
+    set opposite_power to "off"
 else
-	opposite_power='on'
-fi
+    set opposite_power to "on"
+end if
 
-networksetup -setairportpower \"$device\" \"$opposite_power\"
-EOF"
+do shell script "networksetup -setairportpower " & device & " " & opposite_power


### PR DESCRIPTION
For some reason, the Quick Action using a heredoc stopped working after a day. 🤷‍♂️ It works fine from command line, but the Quick Action button on Touch Bar failed to toggle Wi-Fi. When played from Automator, it showed a Shell error similar to the following:

```console
sh: then
command not found
```

When creating a brand new Quick Action in Automator, the original solution works just fine. I suppose it breaks after a while, for whatever reason.